### PR TITLE
check if file exists, do not rely on TEMURIN_TAG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,18 @@ ARG TEMURIN_TAG
 
 FROM eclipse-temurin:$TEMURIN_TAG
 
-ARG TEMURIN_TAG
 MAINTAINER Dwolla Engineering <dev+docker@dwolla.com>
 LABEL org.label-schema.vcs-url="https://github.com/Dwolla/docker-java"
 
-RUN if [ "$TEMURIN_TAG" = "8u322-b06-jdk" ] ; then \
-    SECURITY_FILE_PATH=$JAVA_HOME/jre/lib/security/java.security ; \
-    elif [ "$TEMURIN_TAG" = "8u322-b06-jre" ] ; then \
-    SECURITY_FILE_PATH=$JAVA_HOME/lib/security/java.security ; \
+RUN if [ -f "$JAVA_HOME/jre/lib/security/java.security" ] ; then \
+        SECURITY_FILE_PATH=$JAVA_HOME/jre/lib/security/java.security ; \
+    elif [ -f "$JAVA_HOME/lib/security/java.security" ] ; then \
+        SECURITY_FILE_PATH=$JAVA_HOME/lib/security/java.security ; \
+    elif [ -f "$JAVA_HOME/conf/security/java.security" ] ; then \
+        SECURITY_FILE_PATH=$JAVA_HOME/conf/security/java.security ; \
     else \
-    SECURITY_FILE_PATH=$JAVA_HOME/conf/security/java.security; \
+        echo 'java.security file path not found' ; \
+        exit 98 ; \
     fi && \
     apt-get update && \
     apt-get install -y bash && \


### PR DESCRIPTION
Full credit goes to @bpholt for this idea:

Check if the `java.security` file exists in a given path, and if so use that file path. If path is not one of the three known paths, exit with error "java.security file path not found".

Functionality is maintained, but the Dockerfile no longer has knowledge of/responsibility for "valid" `TEMURIN_TAG` values.