### PR TITLE
activate snyk project on releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: ./.github/actions/build
+      - name: Build and Push Docker Image
+        uses: ./.github/actions/build
         with:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           TEMURIN_TAG: ${{ matrix.temurin_tag }}
+      - name: Active Snyk Project
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
+        run: ./scripts/activate-snyk-project.sh ${{ secrets.SNYK_TOKEN }} java ${{ matrix.temurin_tag }} $(git rev-parse --short "$GITHUB_SHA")

--- a/scripts/activate-snyk-project.sh
+++ b/scripts/activate-snyk-project.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+SNYK_TOKEN=$1
+IMAGE_ID=$2
+TAG=$3
+COMMIT_HASH=$4
+TAG_WITH_COMMIT_HASH="dwolla/$IMAGE_ID:$TAG-$COMMIT_HASH"
+
+function get_snyk_projects() {
+    curl \
+    --silent \
+    -H "Authorization: token $SNYK_TOKEN" \
+    https://snyk.io/api/v1/org/dwolla/projects
+}
+
+function activate_snyk_project() {
+    PROJECT_ID=$1
+    curl \
+    -X POST \
+    --silent \
+    -H "Authorization: token $SNYK_TOKEN" \
+    https://snyk.io/api/v1/org/dwolla/project/"$PROJECT_ID"/activate \
+    > /dev/null
+}
+
+echo "Looking Snyk project with name $TAG_WITH_COMMIT_HASH..."
+SNYK_PROJECT_ID=$(get_snyk_projects | jq -c -r --arg IMAGE_NAME "$TAG_WITH_COMMIT_HASH" '.projects[] | select( .name==$IMAGE_NAME ).id')
+
+if [ -z "$SNYK_PROJECT_ID" ]
+then
+echo "No snyk project found for $TAG_WITH_COMMIT_HASH."
+exit 99
+else
+activate_snyk_project "$SNYK_PROJECT_ID"
+echo "Successfully turned on Snyk monitoring for $TAG_WITH_COMMIT_HASH with project id $SNYK_PROJECT_ID."
+fi


### PR DESCRIPTION
* The `activate-snyk-project.sh` will automatically add images or "projects" to Snyk to be scanned as we push images to dockerhub as part of our gha build workflow
* Note: For now we will manually cleanup "old" image projects to no longer be scanned by Snyk after we ensure they are no longer being used by Dwolla apps