### PR TITLE
import docker image target to Snyk before activating project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,6 @@ jobs:
           TEMURIN_TAG: ${{ matrix.temurin_tag }}
       - name: Active Snyk Project
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: ./scripts/activate-snyk-project.sh ${{ secrets.SNYK_TOKEN }} java ${{ matrix.temurin_tag }} $(git rev-parse --short "$GITHUB_SHA")
+        run: ./scripts/activate-snyk-project.sh java ${{ matrix.temurin_tag }} $(git rev-parse --short "$GITHUB_SHA")
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/scripts/activate-snyk-project.sh
+++ b/scripts/activate-snyk-project.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 
-SNYK_TOKEN=$1
-IMAGE_ID=$2
-TAG=$3
-COMMIT_HASH=$4
+IMAGE_ID=$1
+TAG=$2
+COMMIT_HASH=$3
 TAG_WITH_COMMIT_HASH="dwolla/$IMAGE_ID:$TAG-$COMMIT_HASH"
+
+function get_integrations() {
+     curl \
+    --silent \
+    -H "Authorization: token $SNYK_TOKEN" \
+    https://snyk.io/api/v1/org/dwolla/integrations   
+}
 
 function get_snyk_projects() {
     curl \
@@ -23,14 +29,35 @@ function activate_snyk_project() {
     > /dev/null
 }
 
-echo "Looking Snyk project with name $TAG_WITH_COMMIT_HASH..."
-SNYK_PROJECT_ID=$(get_snyk_projects | jq -c -r --arg IMAGE_NAME "$TAG_WITH_COMMIT_HASH" '.projects[] | select( .name==$IMAGE_NAME ).id')
 
-if [ -z "$SNYK_PROJECT_ID" ]
-then
-echo "No snyk project found for $TAG_WITH_COMMIT_HASH."
+function import_snyk_project() {
+    INTEGRATION_ID=$1
+    curl \
+    -X POST \
+    --silent \
+    https://snyk.io/api/v1/org/dwolla/integrations/"$INTEGRATION_ID"/import \
+    -H "Authorization: token $SNYK_TOKEN" -H "Content-Type: application/json" \
+    -d '{"target": {"name": "'"$TAG_WITH_COMMIT_HASH"'"}}' \
+    > /dev/null
+}
+
+DOCKERHUB_INTEGRATION_ID=$(get_integrations | jq -r '.["docker-hub"]')
+import_snyk_project "$DOCKERHUB_INTEGRATION_ID"
+
+echo "Looking for Snyk project with name $TAG_WITH_COMMIT_HASH..."
+for (( counter=1; counter<=10; counter++ ))
+do  
+    SNYK_PROJECT_ID=$(get_snyk_projects | jq -c -r --arg IMAGE_NAME "$TAG_WITH_COMMIT_HASH" '.projects[] | select( .name==$IMAGE_NAME ).id')
+    if [ -n "$SNYK_PROJECT_ID" ]; then
+    activate_snyk_project "$SNYK_PROJECT_ID"
+    echo "Successfully activated Snyk monitoring for $TAG_WITH_COMMIT_HASH with project id $SNYK_PROJECT_ID."
+    exit 0
+    fi
+    if [ "$counter" -lt 10 ]; then
+    echo "Not found: sleeping 30s then retrying..."
+    sleep 30
+    fi
+done
+
+echo "No snyk project found for $TAG_WITH_COMMIT_HASH, import job may have failed."
 exit 99
-else
-activate_snyk_project "$SNYK_PROJECT_ID"
-echo "Successfully turned on Snyk monitoring for $TAG_WITH_COMMIT_HASH with project id $SNYK_PROJECT_ID."
-fi


### PR DESCRIPTION
Current release process:
1. build and push `dwolla/java:my-tag` to dockerhub
2. activate `dwolla/java:my-tag` in snyk ❌ <- this fails because the project does not exist in snyk yet

Release process with fix:
1. build and push `dwolla/java:my-tag` to dockerhub
2. import `dwolla/java:my-tag` as docker-hub "target" to snyk
3. activate `dwolla/java:my-tag` in snyk ✅ 
